### PR TITLE
Improve camera preview and add terms acceptance

### DIFF
--- a/flutter_express/lib/2_sign_to_text/page_sign_to_text.dart
+++ b/flutter_express/lib/2_sign_to_text/page_sign_to_text.dart
@@ -584,6 +584,8 @@ class _SignToTextPageState extends State<SignToTextPage> {
     final screenSize = MediaQuery.of(context).size;
     final isSmallScreen = screenSize.width < 400;
     final cameraWidth = screenSize.width * 0.8;
+    // Use fixed 4:3 aspect ratio for the container
+    // Camera will fill this space and excess will be cropped
     final cameraHeight = cameraWidth * (4 / 3);
 
     return Scaffold(
@@ -744,11 +746,19 @@ class _SignToTextPageState extends State<SignToTextPage> {
                         _cameraController!.value.isInitialized
                     ? Stack(
                         children: [
-                          // 1) Camera preview (bottom)
+                          // 1) Camera preview (bottom) - uses BoxFit.cover to fill and crop excess
                           Positioned.fill(
-                            child: AspectRatio(
-                              aspectRatio: _cameraController!.value.aspectRatio,
-                              child: CameraPreview(_cameraController!),
+                            child: FittedBox(
+                              fit: BoxFit.cover,
+                              child: SizedBox(
+                                width: _cameraController!
+                                    .value
+                                    .previewSize!
+                                    .height,
+                                height:
+                                    _cameraController!.value.previewSize!.width,
+                                child: CameraPreview(_cameraController!),
+                              ),
                             ),
                           ),
 
@@ -1047,6 +1057,7 @@ class _SignToTextPageState extends State<SignToTextPage> {
                         ),
                         child: TextField(
                           controller: _textController,
+                          readOnly: true,
                           maxLines: null,
                           expands: true,
                           style: GoogleFonts.robotoMono(

--- a/flutter_express/lib/register.dart
+++ b/flutter_express/lib/register.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'dart:convert';
 import '00_services/api_services.dart';
 import '0_components/popup_information.dart';
+import '4_settings/about_page.dart';
 
 class Register extends StatefulWidget {
   const Register({Key? key}) : super(key: key);
@@ -1081,6 +1082,76 @@ class _RegisterState extends State<Register> {
                                 ),
                               ],
                               SizedBox(height: spacing * 1.0),
+
+                              // Terms and Privacy Policy Acceptance
+                              if (!otpStep) ...[
+                                Center(
+                                  child: RichText(
+                                    textAlign: TextAlign.center,
+                                    text: TextSpan(
+                                      style: GoogleFonts.robotoMono(
+                                        fontSize: 12.0,
+                                        color: Colors.grey[700],
+                                        height: 1.4,
+                                      ),
+                                      children: [
+                                        TextSpan(
+                                          text:
+                                              'By registering, you agree to our\n',
+                                        ),
+                                        WidgetSpan(
+                                          child: InkWell(
+                                            onTap: () {
+                                              Navigator.push(
+                                                context,
+                                                MaterialPageRoute(
+                                                  builder: (context) =>
+                                                      TermsConditionsPage(),
+                                                ),
+                                              );
+                                            },
+                                            child: Text(
+                                              'Terms & Conditions',
+                                              style: GoogleFonts.robotoMono(
+                                                fontSize: 12.0,
+                                                color: Colors.blue,
+                                                decoration:
+                                                    TextDecoration.underline,
+                                                height: 1.4,
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                        TextSpan(text: ' and '),
+                                        WidgetSpan(
+                                          child: InkWell(
+                                            onTap: () {
+                                              Navigator.push(
+                                                context,
+                                                MaterialPageRoute(
+                                                  builder: (context) =>
+                                                      PrivacyPolicyPage(),
+                                                ),
+                                              );
+                                            },
+                                            child: Text(
+                                              'Privacy Policy',
+                                              style: GoogleFonts.robotoMono(
+                                                fontSize: 12.0,
+                                                color: Colors.blue,
+                                                decoration:
+                                                    TextDecoration.underline,
+                                                height: 1.4,
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                                SizedBox(height: spacing * 1.0),
+                              ],
 
                               SizedBox(
                                 width: double.infinity,


### PR DESCRIPTION
Camera preview now uses a fixed 4:3 aspect ratio and BoxFit.cover for better cropping and display. The sign-to-text text field is set to read-only. Registration page now displays terms and privacy policy acceptance with clickable links before account creation.