### PR TITLE
Add confirmation dialog before saving profile edits

### DIFF
--- a/flutter_express/lib/5_profile/page_profile.dart
+++ b/flutter_express/lib/5_profile/page_profile.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../00_services/api_services.dart';
 import '../global_variables.dart';
+import '../0_components/popup_confirmation.dart';
 
 class PageProfile extends StatefulWidget {
   const PageProfile({Key? key}) : super(key: key);
@@ -625,6 +626,19 @@ class _EditProfileDialogState extends State<EditProfileDialog> {
                                   lNameError != null) {
                                 return; // Don't proceed if there are validation errors
                               }
+
+                              // Show confirmation dialog
+                              final confirmed = await PopupConfirmation.show(
+                                context,
+                                title: "Save Changes",
+                                message:
+                                    "Are you sure you want to save these changes to your profile?",
+                                confirmText: "Save",
+                                cancelText: "Cancel",
+                              );
+
+                              // If user didn't confirm, return
+                              if (!confirmed) return;
 
                               setState(() => loading = true);
                               final result = await ApiService.editUser(


### PR DESCRIPTION
Introduced a confirmation popup in the profile edit dialog to prompt users before saving changes. This helps prevent accidental profile updates by requiring explicit user confirmation.