### PR TITLE
Update name validation to allow periods

### DIFF
--- a/flutter_express/lib/5_profile/page_profile.dart
+++ b/flutter_express/lib/5_profile/page_profile.dart
@@ -456,15 +456,15 @@ class _EditProfileDialogState extends State<EditProfileDialog> {
 
   // Validation helper functions
   bool hasInvalidNameCharacters(String name) {
-    // Check for numbers and special characters (allow only letters, spaces, hyphens, and apostrophes)
-    return name.contains(RegExp(r'[0-9!@#$%^&*(),.?":{}|<>+=\[\]\\/_~`]'));
+    // Check for numbers and special characters (allow only letters, spaces, hyphens, apostrophes, and periods)
+    return name.contains(RegExp(r'[0-9!@#$%^&*(),?":{}|<>+=\[\]\\/_~`]'));
   }
 
   String? validateName(String value, String fieldName) {
     if (fieldName == "Middle Name") {
       // Middle name is optional but can't have invalid characters
       if (value.trim().isNotEmpty && hasInvalidNameCharacters(value)) {
-        return "Numbers and special characters are not allowed";
+        return "Only letters, spaces, hyphens (-), apostrophes ('), and periods (.) allowed";
       }
       return null;
     } else {
@@ -473,7 +473,7 @@ class _EditProfileDialogState extends State<EditProfileDialog> {
         return "$fieldName is required";
       }
       if (hasInvalidNameCharacters(value)) {
-        return "Numbers and special characters are not allowed";
+        return "Only letters, spaces, hyphens (-), apostrophes ('), and periods (.) allowed";
       }
       return null;
     }

--- a/flutter_express/lib/register.dart
+++ b/flutter_express/lib/register.dart
@@ -186,7 +186,7 @@ class _RegisterState extends State<Register> {
           const SizedBox(width: 8.0),
           Expanded(
             child: Text(
-              "Numbers and special characters not allowed",
+              "Only letters, spaces, hyphens (-), apostrophes ('), and periods (.) allowed",
               style: GoogleFonts.robotoMono(
                 color: Colors.red,
                 fontSize: isSmallScreen ? 12.0 : 14.0,


### PR DESCRIPTION
Modified name validation logic and error messages to permit periods in addition to letters, spaces, hyphens, and apostrophes. This change improves user experience for names containing periods.